### PR TITLE
[csv-to-docs] Clarify doc and csv references

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,41 @@ This tool expects a project to be sctructured as follows:
 
 * rename module to `medic-configurer`
 * remove `beta-` prefix from `--version` output
+
+# csv-to-docs
+
+To convert CSV to JSON docs, use the `csv-to-docs` action.
+
+By default, values are parsed as strings.  To parse a CSV column as a JSON type, prefix a data type to the column definition, e.g.
+
+	column_1,bool:column_2,int:column_3,date:column_4
+
+To reference other docs, there are a number of options:
+
+## Reference to a row of CSV
+
+1. `_id` of doc at row `N` of csv file `F`
+
+	csv:F:id>target_property_name
+
+2. entire doc at row `N` of csv file `F`
+
+	csv:F:doc>target_property_name
+
+3. value of field `some_field` of doc at row `N` of csv file `F`
+
+	csv:F:.some_field>target_property_name
+
+## Reference to a doc by matching properties
+
+1. `_id` of doc with properties X=a and Y=b where property P matches this column's value
+
+	match=P:X=a&Y=y:id>target_property_name
+
+2. entire doc with properties X=a and Y=b where property P matches this column's value
+
+	match=P:X=a&Y=y:doc>target_property_name
+
+3. value of field `some_field` of doc with properties X=a and Y=b where property P matches this column's value
+
+	match=P:X=a&Y=y:.some_field>target_property_name

--- a/test/data/csv-to-docs/csv/person.csv
+++ b/test/data/csv-to-docs/csv/person.csv
@@ -1,4 +1,4 @@
-csv:household:parent,family_name,name,date:date_of_birth,phone,int:child_count,csv:widget>code_name:favourite_widget
+csv:place.household:id>parent,family_name,name,date:date_of_birth,phone,int:child_count,match=code_name:form=widget:id>favourite_widget
 1,Atkins,Anna,1987-12-03,+447890000001,1,a694
 2,Atkins,Anna,1987-12-03,+447890000001,1,a694
 2,Burns,Beatrice,1979-01-31,+447890000002,2,b912

--- a/test/data/csv-to-docs/csv/report.follow_up.csv
+++ b/test/data/csv-to-docs/csv/report.follow_up.csv
@@ -1,3 +1,3 @@
-csv:person:chw_id,name,int:field.z_score,bool:field.happy,field.notes,csv:household:field.fam
+csv:person:id>chw_id,name,int:field.z_score,bool:field.happy,field.notes,csv:place.household:id>field.fam
 1,Charlie Chalk,52,true,A boisterous fellow,1
 2,Donnie Darko,64,false,A troubled youth,2

--- a/test/data/csv-to-docs/csv/report.megamatch.csv
+++ b/test/data/csv-to-docs/csv/report.megamatch.csv
@@ -1,0 +1,3 @@
+name,csv:report.widget:id>widgetId_fromCSV,csv:report.widget:doc>widgetDoc_fromCSV,csv:report.widget:.description>widgetDescription_fromCSV,match=code_name:type=data_record&form=widget:id>widgetId_fromMatch,match=code_name:type=data_record&form=widget:doc>widgetDoc_fromMatch,match=code_name:type=data_record&form=widget:.description>widgetDescription_fromMatch
+finesse,1,1,1,a694,a694,a694
+brute force,2,2,2,b912,b912,b912

--- a/test/data/csv-to-docs/expected-json_docs/017648ca-a4cf-5171-93b7-852ed049e777.doc.json
+++ b/test/data/csv-to-docs/expected-json_docs/017648ca-a4cf-5171-93b7-852ed049e777.doc.json
@@ -1,13 +1,17 @@
 {
   "form": "follow_up",
   "type": "data_record",
-  "chw_id": "32120a8b-9432-544b-ab61-2631440255ec",
+  "chw_id": {
+    "_id": "32120a8b-9432-544b-ab61-2631440255ec"
+  },
   "name": "Charlie Chalk",
   "field": {
     "z_score": 52,
     "happy": true,
     "notes": "A boisterous fellow",
-    "fam": "cc56b63e-aade-5e30-9f06-c4dcd31587ff"
+    "fam": {
+      "_id": "cc56b63e-aade-5e30-9f06-c4dcd31587ff"
+    }
   },
   "_id": "017648ca-a4cf-5171-93b7-852ed049e777"
 }

--- a/test/data/csv-to-docs/expected-json_docs/32120a8b-9432-544b-ab61-2631440255ec.doc.json
+++ b/test/data/csv-to-docs/expected-json_docs/32120a8b-9432-544b-ab61-2631440255ec.doc.json
@@ -1,11 +1,15 @@
 {
   "type": "person",
-  "parent": "cc56b63e-aade-5e30-9f06-c4dcd31587ff",
+  "parent": {
+    "_id": "cc56b63e-aade-5e30-9f06-c4dcd31587ff"
+  },
   "family_name": "Atkins",
   "name": "Anna",
   "date_of_birth": "1987-12-03T00:00:00.000Z",
   "phone": "+447890000001",
   "child_count": 1,
-  "favourite_widget": "a4e71523-2758-56a3-9fd0-fb5d1a280277",
+  "favourite_widget": {
+    "_id": "a4e71523-2758-56a3-9fd0-fb5d1a280277"
+  },
   "_id": "32120a8b-9432-544b-ab61-2631440255ec"
 }

--- a/test/data/csv-to-docs/expected-json_docs/364c2a17-b249-5396-8733-586455e3be97.doc.json
+++ b/test/data/csv-to-docs/expected-json_docs/364c2a17-b249-5396-8733-586455e3be97.doc.json
@@ -1,13 +1,17 @@
 {
   "form": "follow_up",
   "type": "data_record",
-  "chw_id": "93af26f8-af91-5a2c-ad2a-e6b92fab0e1c",
+  "chw_id": {
+    "_id": "93af26f8-af91-5a2c-ad2a-e6b92fab0e1c"
+  },
   "name": "Donnie Darko",
   "field": {
     "z_score": 64,
     "happy": false,
     "notes": "A troubled youth",
-    "fam": "40f8bfc0-0757-5a7f-ba60-5abe0665b3c8"
+    "fam": {
+      "_id": "40f8bfc0-0757-5a7f-ba60-5abe0665b3c8"
+    }
   },
   "_id": "364c2a17-b249-5396-8733-586455e3be97"
 }

--- a/test/data/csv-to-docs/expected-json_docs/5398e690-22e2-576f-bac5-0389508d41a6.doc.json
+++ b/test/data/csv-to-docs/expected-json_docs/5398e690-22e2-576f-bac5-0389508d41a6.doc.json
@@ -1,11 +1,15 @@
 {
   "type": "person",
-  "parent": "40f8bfc0-0757-5a7f-ba60-5abe0665b3c8",
+  "parent": {
+    "_id": "40f8bfc0-0757-5a7f-ba60-5abe0665b3c8"
+  },
   "family_name": "Burns",
   "name": "Beatrice",
   "date_of_birth": "1979-01-31T00:00:00.000Z",
   "phone": "+447890000002",
   "child_count": 2,
-  "favourite_widget": "dc10934a-64e1-5243-bd8c-74394a4c66c3",
+  "favourite_widget": {
+    "_id": "dc10934a-64e1-5243-bd8c-74394a4c66c3"
+  },
   "_id": "5398e690-22e2-576f-bac5-0389508d41a6"
 }

--- a/test/data/csv-to-docs/expected-json_docs/80f30941-5dc4-58ce-8639-8470058e6d55.doc.json
+++ b/test/data/csv-to-docs/expected-json_docs/80f30941-5dc4-58ce-8639-8470058e6d55.doc.json
@@ -1,0 +1,28 @@
+{
+  "form": "megamatch",
+  "type": "data_record",
+  "name": "finesse",
+  "widgetId_fromCSV": {
+    "_id": "a4e71523-2758-56a3-9fd0-fb5d1a280277"
+  },
+  "widgetDoc_fromCSV": {
+    "form": "widget",
+    "type": "data_record",
+    "code_name": "a694",
+    "description": "small and useful",
+    "_id": "a4e71523-2758-56a3-9fd0-fb5d1a280277"
+  },
+  "widgetDescription_fromCSV": "small and useful",
+  "widgetId_fromMatch": {
+    "_id": "a4e71523-2758-56a3-9fd0-fb5d1a280277"
+  },
+  "widgetDoc_fromMatch": {
+    "form": "widget",
+    "type": "data_record",
+    "code_name": "a694",
+    "description": "small and useful",
+    "_id": "a4e71523-2758-56a3-9fd0-fb5d1a280277"
+  },
+  "widgetDescription_fromMatch": "small and useful",
+  "_id": "80f30941-5dc4-58ce-8639-8470058e6d55"
+}

--- a/test/data/csv-to-docs/expected-json_docs/93af26f8-af91-5a2c-ad2a-e6b92fab0e1c.doc.json
+++ b/test/data/csv-to-docs/expected-json_docs/93af26f8-af91-5a2c-ad2a-e6b92fab0e1c.doc.json
@@ -1,11 +1,15 @@
 {
   "type": "person",
-  "parent": "40f8bfc0-0757-5a7f-ba60-5abe0665b3c8",
+  "parent": {
+    "_id": "40f8bfc0-0757-5a7f-ba60-5abe0665b3c8"
+  },
   "family_name": "Atkins",
   "name": "Anna",
   "date_of_birth": "1987-12-03T00:00:00.000Z",
   "phone": "+447890000001",
   "child_count": 1,
-  "favourite_widget": "a4e71523-2758-56a3-9fd0-fb5d1a280277",
+  "favourite_widget": {
+    "_id": "a4e71523-2758-56a3-9fd0-fb5d1a280277"
+  },
   "_id": "93af26f8-af91-5a2c-ad2a-e6b92fab0e1c"
 }

--- a/test/data/csv-to-docs/expected-json_docs/b5eb1796-b737-5b6f-b197-1f54e574864b.doc.json
+++ b/test/data/csv-to-docs/expected-json_docs/b5eb1796-b737-5b6f-b197-1f54e574864b.doc.json
@@ -1,0 +1,28 @@
+{
+  "form": "megamatch",
+  "type": "data_record",
+  "name": "brute force",
+  "widgetId_fromCSV": {
+    "_id": "dc10934a-64e1-5243-bd8c-74394a4c66c3"
+  },
+  "widgetDoc_fromCSV": {
+    "form": "widget",
+    "type": "data_record",
+    "code_name": "b912",
+    "description": "large and unwieldy",
+    "_id": "dc10934a-64e1-5243-bd8c-74394a4c66c3"
+  },
+  "widgetDescription_fromCSV": "large and unwieldy",
+  "widgetId_fromMatch": {
+    "_id": "dc10934a-64e1-5243-bd8c-74394a4c66c3"
+  },
+  "widgetDoc_fromMatch": {
+    "form": "widget",
+    "type": "data_record",
+    "code_name": "b912",
+    "description": "large and unwieldy",
+    "_id": "dc10934a-64e1-5243-bd8c-74394a4c66c3"
+  },
+  "widgetDescription_fromMatch": "large and unwieldy",
+  "_id": "b5eb1796-b737-5b6f-b197-1f54e574864b"
+}


### PR DESCRIPTION
Closes #32
Closes #36
Closes #37
 
@abbyad hopefully this (and the included documentation in `README.md`) should clean up ambiguities with columns that reference other docs or tables.  Also this will allow "legacy" mode by choosing whether to include a document or just its `_id`.